### PR TITLE
Add basic Astro site skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# kanekoshoyu.github.io
-Website
+# Solarpunk Marketing Site
+
+This repository contains a simple marketing site themed around solarpunk. It uses **[Astro](https://astro.build)** to generate static pages.
+
+## Development
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start the dev server
+   ```bash
+   npm run dev
+   ```
+
+## Building
+
+To generate a production build:
+```bash
+npm run build
+```
+The output will be in the `dist` folder.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'https://kanekoshoyu.github.io',
+});

--- a/index.html
+++ b/index.html
@@ -1,1 +1,68 @@
-Hello World
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Solarpunk Marketing</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: system-ui, sans-serif;
+        color: #333;
+      }
+      a { color: #56ab2f; }
+      .hero {
+        text-align: center;
+        padding: 4rem 1rem;
+        background: linear-gradient(to bottom, #a8e063, #56ab2f);
+        color: white;
+      }
+      .hero .btn {
+        display: inline-block;
+        margin-top: 1rem;
+        padding: 0.75rem 1.5rem;
+        background-color: #fff;
+        color: #56ab2f;
+        border-radius: 4px;
+        text-decoration: none;
+        font-weight: bold;
+      }
+      .services {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
+        padding: 2rem 1rem;
+        background: #f0f8f0;
+      }
+      .service {
+        flex: 1 1 200px;
+        margin: 1rem;
+        padding: 1rem;
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="hero">
+      <h1>Solarpunk Marketing</h1>
+      <p>Bright futures through sustainable storytelling.</p>
+      <a href="#services" class="btn">Discover Our Services</a>
+    </div>
+    <section id="services" class="services">
+      <div class="service">
+        <h2>Eco Branding</h2>
+        <p>We craft environmentally conscious brands that resonate.</p>
+      </div>
+      <div class="service">
+        <h2>Community Engagement</h2>
+        <p>Connect with audiences to build a greener tomorrow.</p>
+      </div>
+      <div class="service">
+        <h2>Future Strategies</h2>
+        <p>Marketing solutions for a sustainable future.</p>
+      </div>
+    </section>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kanekoshoyu.github.io",
+  "version": "1.0.0",
+  "description": "Solarpunk marketing site built with Astro",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0"
+  }
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,22 @@
+---
+title: "Solarpunk Marketing"
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{title}</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: system-ui, sans-serif;
+        color: #333;
+      }
+      a { color: #56ab2f; }
+    </style>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,59 @@
+---
+layout: '../layouts/Base.astro'
+---
+
+<div class="hero">
+  <h1>Solarpunk Marketing</h1>
+  <p>Bright futures through sustainable storytelling.</p>
+  <a href="#services" class="btn">Discover Our Services</a>
+</div>
+
+<section id="services" class="services">
+  <div class="service">
+    <h2>Eco Branding</h2>
+    <p>We craft environmentally conscious brands that resonate.</p>
+  </div>
+  <div class="service">
+    <h2>Community Engagement</h2>
+    <p>Connect with audiences to build a greener tomorrow.</p>
+  </div>
+  <div class="service">
+    <h2>Future Strategies</h2>
+    <p>Marketing solutions for a sustainable future.</p>
+  </div>
+</section>
+
+<style>
+.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+  background: linear-gradient(to bottom, #a8e063, #56ab2f);
+  color: white;
+}
+.hero .btn {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background-color: #fff;
+  color: #56ab2f;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: bold;
+}
+.services {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  padding: 2rem 1rem;
+  background: #f0f8f0;
+}
+.service {
+  flex: 1 1 200px;
+  margin: 1rem;
+  padding: 1rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+</style>
+


### PR DESCRIPTION
## Summary
- initialize Astro project structure
- add solarpunk marketing page and layout
- provide minimal Astro configuration and package info
- update README with development instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68430604fc7483289a6375c3229dca0f